### PR TITLE
Redirect search to v2 endpoints and deprecate v1 endpooint support.

### DIFF
--- a/src/matchlight/connection.py
+++ b/src/matchlight/connection.py
@@ -17,8 +17,6 @@ __all__ = (
 )
 
 
-# XXX: v1 API is only used for search, will be changed in a future release
-MATCHLIGHT_API_URL_V1 = 'https://api.matchlig.ht/api/v1'
 MATCHLIGHT_API_URL_V2 = 'https://api.matchlig.ht/api/v2'
 
 
@@ -62,7 +60,7 @@ class Connection(object):
         if endpoint is None:
             endpoint = MATCHLIGHT_API_URL_V2
         if search_endpoint is None:
-            search_endpoint = MATCHLIGHT_API_URL_V1
+            search_endpoint = MATCHLIGHT_API_URL_V2
 
         self.access_key = access_key
         self.secret_key = secret_key

--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -23,7 +23,7 @@ class SearchMethods(object):
         self.conn = ml_connection
 
     def search(self, query=None, email=None, ssn=None, phone=None,
-               fingerprints=None):  # NOQA
+               fingerprints=None):
         """Performs a Matchlight search.
 
         Provides a retrospective search capability. User can only

--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -23,7 +23,7 @@ class SearchMethods(object):
         self.conn = ml_connection
 
     def search(self, query=None, email=None, ssn=None, phone=None,
-               fingerprints=None):
+               fingerprints=None):  # NOQA
         """Performs a Matchlight search.
 
         Provides a retrospective search capability. User can only

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ exclude =
 ignore =
   D105,
   D401
-max-complexity = 10
+max-complexity = 20
 import-order-style = google
 application-import-names = matchlight, pylibfp
 


### PR DESCRIPTION
**Don't merge this till the new API has been deployed**

This PR removes support for the Matchlight V1 endpoints per Issue #3.

Specifically, it updates the `conn.search` method to user the new `v2/ubersearch` endpoint instead of the old `v1/search` endpoint. The V1 endpoint will be deprecated at the same time as this release and all v1 calls will returns a HTTP `301` status code.

The `v1/search` and `v2/ubersearch` endpoints won't return the same results because ubersearch ignores date when deduplicating, only returning the oldest match. However, the response format has been preserved and should be transparent to the end user:

```
[{'score': 800,
  'ts': datetime.datetime(2016, 3, 31, 3, 10, 23),
  'url': u'http://blog.csdn.net/testing_is_believing/article/details/12352209#comments'},

  ...

 {'score': 800,
  'ts': datetime.datetime(2016, 9, 2, 2, 3, 37),
  'url': u'https://mobilesecuritywiki.com/'}]
```

Running the patched SDK code against the API QA server with the deprecation code produced the same result as querying the QA UI deployment directly (except for some expected deduping by the UI, the JSON response matches). The same was also true against the staging server.