### PR TITLE
Add alerts interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,12 @@ clean_requirements:
 clean_wheels:
 	rm -rf wheelhouse/
 
+.PHONY: docs
 docs:
-	@python setup.py build_sphinx
+	tox -e docs
+
+serve_docs:
+	tox -e docs,serve-docs
 
 # Wheel generation targets borrowed from sdispater/pendulum:
 # <https://github.com/sdispater/pendulum/blob/master/Makefile>
@@ -47,9 +51,6 @@ $(REQUIREMENTS_ARTIFACTS): $(REQUIREMENTS_DIR)/src/%.in
 	pip-compile $< -o $@
 
 requirements: $(patsubst %,$(REQUIREMENTS_ARTIFACTS),$(REQUIREMENTS_TARGETS))
-
-serve_docs:
-	tox -e docs,serve-docs
 
 tox:
 	@pyenv local ${PYENVS}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -31,6 +31,14 @@ Record Methods
 .. autoclass:: matchlight.record.RecordMethods
    :members:
 
+.. _alertmethods:
+
+Alert Methods
+**************
+
+.. autoclass:: matchlight.alert.AlertMethods
+   :members:
+
 .. _feedmethods:
 
 Data Feeds
@@ -69,6 +77,12 @@ Record
 ******
 
 .. autoclass:: matchlight.Record
+   :members:
+
+Alert
+******
+
+.. autoclass:: matchlight.Alert
    :members:
 
 Feed

--- a/src/matchlight/__init__.py
+++ b/src/matchlight/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import pkg_resources
 
+from .alert import Alert, AlertMethods
 from .connection import Connection, MATCHLIGHT_API_URL_V2
 from .error import (
     APIError,
@@ -17,6 +18,8 @@ from .search import SearchMethods
 
 
 __all__ = (
+    'Alert',
+    'AlertMethods',
     'APIError',
     'Connection',
     'ConnectionError',
@@ -48,6 +51,9 @@ class Matchlight(object):
     (projects, and records).
 
     Attributes:
+        alerts: :class:`~matchlight.alert.AlertMethods` object
+            with access to alert methods for Matchlight Fingerprint
+            Monitoring.
         projects: :class:`~matchlight.project.ProjectMethods` object
             with access to project methods for Matchlight Fingerprint
             Monitoring.
@@ -81,6 +87,7 @@ class Matchlight(object):
         """
         self.conn = Connection(
             access_key=access_key, secret_key=secret_key, **kwargs)
+        self.alerts = AlertMethods(self.conn)
         self.projects = ProjectMethods(self.conn)
         self.feeds = FeedMethods(self.conn)
         self.records = RecordMethods(self.conn)

--- a/src/matchlight/alert.py
+++ b/src/matchlight/alert.py
@@ -108,7 +108,8 @@ class AlertMethods(object):
         """Returns a list of alerts.
 
         Providing a **limit** keyword argument will limit the number of alerts
-        returned. recomended is 50.
+        returned. The request may time out if this is set too high, a limit of
+        50 is recomended to avoid timeouts.
 
         Providing an optional **seen** keyword argument will only
         return alerts that match that property

--- a/src/matchlight/alert.py
+++ b/src/matchlight/alert.py
@@ -90,8 +90,7 @@ class Alert(object):
 
 
 class AlertMethods(object):
-    """Provides methods for interfacing with the alerts API.
-    """
+    """Provides methods for interfacing with the alerts API."""
 
     def __init__(self, ml_connection):  # noqa: D205,D400
         """Initializes an alerts interface with the given Matchlight

--- a/src/matchlight/alert.py
+++ b/src/matchlight/alert.py
@@ -165,6 +165,19 @@ class AlertMethods(object):
                 Alert(number="1025",
                 id="f9427dd5a24d4a98b2069004g04c2977")]
 
+            Request sets of alerts using pagination::
+
+                >>> ml.alerts.filter(limit=50)
+                [<Alert(number="1027",
+                id="625a732ad247beab18595z951c2088a3")>,
+                Alert(number="1026",
+                id="f9427dd5a24d4a98b2069004g04c2977")...
+                >>> ml.alerts.filter(limit=50, offset=50)
+                [<Alert(number="977",
+                id="59d5a791g8d4436aaffe64e4b15474a5")>,
+                Alert(number="976",
+                id="6b1001aaec5a48f19d17171169eebb56")...
+
         Args:
             limit (:obj:`int`):
                 Don't return more than this number of alerts.

--- a/src/matchlight/alert.py
+++ b/src/matchlight/alert.py
@@ -91,23 +91,6 @@ class Alert(object):
 
 class AlertMethods(object):
     """Provides methods for interfacing with the alerts API.
-
-    Examples:
-
-        Get alert by alert id::
-
-            >>> alert = ml.alerts.get("0760570a2c4a4ea68d526f58bab46cbd")
-            >>> alert
-            <Alert(number=1024,
-            id="0760570a2c4a4ea68d526f58bab46cbd")>
-
-        Archive an alert::
-
-            >>> alert
-            <Alert(number=1024,
-            id="0760570a2c4a4ea68d526f58bab46cbd")>
-            >>> ml.alert.edit(alert, archived=True)
-
     """
 
     def __init__(self, ml_connection):  # noqa: D205,D400
@@ -146,7 +129,7 @@ class AlertMethods(object):
         Providing an optional **offset** keyword argument will skip this number
         of alerts from being returned.
 
-        Example:
+        Examples:
             Request all unseen alerts::
 
                 >>> ml.alerts.filter(seen=False, limit=50)
@@ -239,6 +222,18 @@ class AlertMethods(object):
 
     def edit(self, alert_id, seen=None, archived=None):
         """Edits an alert.
+
+        Example:
+            Archive an alert::
+
+                >>> alert
+                <Alert(number=1024,
+                id="0760570a2c4a4ea68d526f58bab46cbd")>
+                >>> ml.alert.edit(alert, archived=True)
+                {
+                    'seen': True,
+                    'archived': True
+                }
 
         Arguments:
             alert (:obj:`str`): An alert id.

--- a/src/matchlight/alert.py
+++ b/src/matchlight/alert.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import datetime
+import json
 
 import matchlight.error
 
@@ -51,8 +52,8 @@ class Alert(object):
             url_metadata=mapping['url_metadata'],
             ctime=mapping['ctime'],
             mtime=mapping['mtime'],
-            seen=mapping['seen'],
-            archived=mapping['archived'],
+            seen=True if mapping['seen'] == 'true' else False,
+            archived=True if mapping['archived'] == 'true' else False,
         )
 
     @property
@@ -197,6 +198,40 @@ class AlertMethods(object):
                 return
             else:
                 raise
+
+    def edit(self, alert, seen=None, archived=None):
+        """Edits an alert.
+
+        Arguments:
+            alert (:class:`~.Alert` or :obj:`str`): An alert instance or id.
+            seen (:obj:`bool`, optional):
+            archived (:obj:`bool`, optional):
+
+        Returns:
+            :class:`~.Alert`: Updated alert instance.
+
+            Note that this method mutates any alert instances passed.
+
+        """
+        if not isinstance(alert, Alert):
+            alert = self.get(alert)
+
+        data = {}
+        if seen is not None:
+            data['seen'] = 1 if seen is True else 0
+
+        if archived is not None:
+            data['archived'] = 1 if archived is True else 0
+
+        response = self.conn.request(
+            '/alert/{}/edit'.format(alert.id),
+            data=json.dumps(data)
+        )
+        response = response.json()
+
+        alert.seen = True if response['seen'] == 'true' else False
+        alert.archived = True if response['archived'] == 'true' else False
+        return alert
 
     def __iter__(self):
         return iter(self.filter())

--- a/src/matchlight/alert.py
+++ b/src/matchlight/alert.py
@@ -238,10 +238,10 @@ class AlertMethods(object):
         """
         data = {}
         if seen is not None:
-            data['seen'] = 1 if seen is True else 0
+            data['seen'] = seen
 
         if archived is not None:
-            data['archived'] = 1 if archived is True else 0
+            data['archived'] = archived
 
         response = self.conn.request(
             '/alert/{}/edit'.format(alert_id),
@@ -249,8 +249,8 @@ class AlertMethods(object):
         )
         response = response.json()
         return {
-            'seen': True if response['seen'] == 'true' else False,
-            'archived': True if response['archived'] == 'true' else False
+            'seen': response['seen'],
+            'archived': response['archived']
         }
 
     def get_details(self, alert_id):

--- a/src/matchlight/alert.py
+++ b/src/matchlight/alert.py
@@ -1,0 +1,202 @@
+"""An interface for creating and retrieving alerts in Matchlight."""
+from __future__ import absolute_import
+
+import datetime
+
+import matchlight.error
+
+
+__all__ = (
+    'Alert',
+    'AlertMethods',
+)
+
+
+class Alert(object):
+    """Represents an alert."""
+
+    def __init__(self, id, number, url, url_metadata, ctime, mtime, seen,
+                 archived):
+        """Initializes a new alert.
+
+        Args:
+            id (:obj:`str`): A 128-bit UUID.
+            number (:obj:`int`): The account specific alert number.
+            url (:obj:`str`): The url where the match was found.
+            score (:obj:`int`): The matchlight score (1-800).
+            ctime (:obj:`int`, optional): A Unix timestamp of the
+                alert creation timestamp.
+            mtime (:obj:`int`, optional): A Unix timestamp of the
+                alert last modification date timestamp.
+            seen (:obj:`bool`): User specific flag.
+            archived (:obj:`bool`): User specific flag.
+
+        """
+        self.id = id
+        self.number = number
+        self.url = url
+        self.url_metadata = url_metadata
+        self.ctime = ctime
+        self.mtime = mtime
+        self.seen = seen
+        self.archived = archived
+
+    @classmethod
+    def from_mapping(cls, mapping):
+        """Creates a new alert instance from the given mapping."""
+        return cls(
+            id=mapping['id'],
+            number=mapping['alert_number'],
+            url=mapping['url'],
+            url_metadata=mapping['url_metadata'],
+            ctime=mapping['ctime'],
+            mtime=mapping['mtime'],
+            seen=mapping['seen'],
+            archived=mapping['archived'],
+        )
+
+    @property
+    def last_modified(self):
+        """:class:`datetime.datetime`: The last modified timestamp."""
+        return datetime.datetime.fromtimestamp(self.mtime)
+
+    @property
+    def date(self):
+        """:class:`datetime.datetime`: The date created timestamp."""
+        return datetime.datetime.fromtimestamp(self.ctime)
+
+    def __repr__(self):  # pragma: no cover
+        return '<Alert(number="{}", id="{}")>'.format(
+            self.number,
+            self.id
+        )
+
+
+class AlertMethods(object):
+    """Provides methods for interfacing with the alerts API.
+
+    Examples:
+
+        Get alert by alert id::
+
+            >>> alert = ml.alerts.get("0760570a2c4a4ea68d526f58bab46cbd")
+            >>> alert
+            <Alert(number=1024,
+            id="0760570a2c4a4ea68d526f58bab46cbd")>
+
+        Archive an alert::
+
+            >>> alert
+            <Alert(number=1024,
+            id="0760570a2c4a4ea68d526f58bab46cbd")>
+            >>> ml.alert.edit(alert, archived=True)
+
+    """
+
+    def __init__(self, ml_connection):  # noqa: D205,D400
+        """Initializes an alerts interface with the given Matchlight
+        connection.
+
+        Args:
+            ml_connection (:class:`~.Connection`): A Matchlight
+                connection instance.
+
+        """
+        self.conn = ml_connection
+
+    def all(self):
+        """Returns all alerts associated with the account."""
+        return self.filter()
+
+    def filter(self, seen=None, archived=None, project=None):
+        """Returns a list of alerts.
+
+        Providing an optional **seen** keyword argument will only
+        return alerts that match that property
+
+        Providing an optional **archived** keyword argument will only
+        return alerts that match that property
+
+        Providing an optional **project** keyword argument will only
+        return alerts that are associated with a specific project.
+
+        Example:
+            Request all unseen alerts::
+
+                >>> ml.alerts.filter(seen=False)
+                [<Alert(number="1024",
+                id="625a732ad0f247beab18595z951c2088a3")>,
+                Alert(number="1025",
+                id="f9427dd5a24d4a98b2069004g04c2977")]
+
+            Request all alerts for a project::
+
+                >>> my_project
+                <Project(name="Super Secret Algorithm", type="source_code")>
+                >>> ml.alerts.filter(project=my_project)
+                [<Alert(number="1024",
+                id="625a732ad0f247beab18595z951c2088a3")>,
+                Alert(number="1025",
+                id="f9427dd5a24d4a98b2069004g04c2977")]
+
+        Args:
+            seen (:obj:`bool`, optional):
+            archived (:obj:`bool`, optional):
+            project (:class:`~.Project`, optional): a project object.
+                Defaults to all projects if not specified.
+
+        Returns:
+            :obj:`list` of :class:`~.Alert`: List of alerts that
+                are associated with a project.
+
+        """
+        if seen is not None:
+            seen_int = 1 if seen is True else 0
+        else:
+            seen_int = None
+
+        if archived is not None:
+            archived_int = 1 if archived is True else 0
+        else:
+            archived_int = None
+
+        if project is not None:
+            upload_token = project.upload_token
+        else:
+            upload_token = None
+
+        response = self.conn.request(
+            '/alerts',
+            params={
+                'seen': seen_int,
+                'archived': archived_int,
+                'upload_token_filter': upload_token
+            }
+        )
+        alerts = []
+        for payload in response.json().get('data', []):
+            alerts.append(Alert.from_mapping(payload))
+        return alerts
+
+    def get(self, alert_id):
+        """Returns an alert by the given alert ID.
+
+        Args:
+            alert_id (:obj:`str`): The alert identifier.
+
+        Returns:
+           :class:`~.Alert`: A alert instance.
+
+        """
+        try:
+            response = self.conn.request('/alert/{}'.format(alert_id))
+            return Alert.from_mapping(response.json())
+        # for consistency since records.get() returns None if not found.
+        except matchlight.error.APIError as err:
+            if err.args[0] == 404:
+                return
+            else:
+                raise
+
+    def __iter__(self):
+        return iter(self.filter())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,7 @@ def alert_payload(id):
     return {
         'id': id,
         'alert_number': 10,
+        'type': 'pii',
         'url': 'https://terbiumlabs.com/matchlight.html',
         'url_metadata': {
             'description': 'Matchlight provides intelligence on your most imp',
@@ -101,6 +102,25 @@ def alert_payload(id):
         'mtime': time.time(),
         'seen': 'true',
         'archived': 'true',
+    }
+
+
+@pytest.fixture(scope='function')
+def alert_details_pii_payload():
+    """An alert details payload artifact for a pii alert."""
+    return {
+        'details': {
+            'pii': [
+                {
+                    'email': 'o****@gmail.com',
+                    'first': 'a****',
+                    'last': 'b****',
+                    'record_id': 'd3c59d38c4054f62876a2a7a3dca41ca'
+                }
+            ]
+        },
+        'notes': '',
+        'type': 'pii'
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,12 @@ def connection(access_key, secret_key):
 
 
 @pytest.fixture(scope='function')
+def id():
+    """Provides a fake id in the form of a UUID4."""
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(scope='function')
 def number_of_records():
     """A record count fixture."""
     return 10
@@ -78,3 +84,27 @@ def project_payload(project_name, project_type, upload_token,
 def project(project_payload):
     """A project instance fixture, parametrized by project type."""
     return matchlight.Project.from_mapping(project_payload)
+
+
+@pytest.fixture(scope='function')
+def alert_payload(id):
+    """An alert payload artifact."""
+    return {
+        'id': id,
+        'alert_number': 10,
+        'url': 'https://terbiumlabs.com/matchlight.html',
+        'url_metadata': {
+            'description': 'Matchlight provides intelligence on your most imp',
+            'tor_only': 'false'
+        },
+        'ctime': time.time(),
+        'mtime': time.time(),
+        'seen': 'true',
+        'archived': 'true',
+    }
+
+
+@pytest.fixture
+def alert(alert_payload):
+    """An alert instance fixture."""
+    return matchlight.Alert.from_mapping(alert_payload)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,25 @@ def number_of_unseen_alerts():
 
 
 @pytest.fixture(scope='function')
+def document(request):
+    """A document mapping fixture."""
+    return {
+        'id': uuid.uuid4().hex,
+        'name': 'Document record',
+        'description': '',
+        'ctime': time.time(),
+        'mtime': time.time(),
+        'metadata': {},
+    }
+
+
+@pytest.fixture(scope='function')
+def document_record(document):
+    """A document record fixture."""
+    return matchlight.Record(**document)
+
+
+@pytest.fixture(scope='function')
 def project_name():
     """A project name fixture."""
     return 'Test Project'
@@ -87,7 +106,7 @@ def project(project_payload):
 
 
 @pytest.fixture(scope='function')
-def alert_payload(id):
+def alert_payload(id, upload_token):
     """An alert payload artifact."""
     return {
         'id': id,
@@ -102,6 +121,7 @@ def alert_payload(id):
         'mtime': time.time(),
         'seen': 'true',
         'archived': 'true',
+        'upload_token': upload_token
     }
 
 

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -1,0 +1,197 @@
+"""Unit tests the alert methods of the Matchlight SDK."""
+import datetime
+import json
+import uuid
+
+import httpretty
+import pytest
+
+import matchlight
+
+
+@pytest.mark.httpretty
+def test_alert_get(connection, alert, alert_payload):
+    """Verifies alert get responses."""
+    httpretty.register_uri(
+        httpretty.GET, '{}/alert/{}'.format(
+            matchlight.MATCHLIGHT_API_URL_V2,
+            alert.id
+        ),
+        responses=[
+            httpretty.Response(
+                body=json.dumps(alert_payload),
+                content_type='application/json',
+                status=200
+            ),
+            httpretty.Response(
+                body='{}',
+                content_type='application/json',
+                status=404
+            ),
+            httpretty.Response(
+                body='{}',
+                content_type='application/json',
+                status=500
+            ),
+        ]
+    )
+    alert_ = connection.alerts.get(alert.id)
+    assert alert.id == alert_.id
+
+    alert_ = connection.alerts.get(alert.id)
+    assert alert_ is None
+
+    with pytest.raises(matchlight.error.ConnectionError):
+        connection.alerts.get(alert.id)
+
+
+@pytest.mark.httpretty
+def test_alert_dates(connection, alert, alert_payload):
+    """Verifies alert date objects are converted correctly."""
+    httpretty.register_uri(
+        httpretty.GET, '{}/alert/{}'.format(
+            matchlight.MATCHLIGHT_API_URL_V2,
+            alert.id
+        ),
+        body=json.dumps(alert_payload),
+        content_type='application/json',
+        status=200
+    )
+    alert_ = connection.alerts.get(alert.id)
+    assert isinstance(alert_.date, datetime.datetime)
+    assert isinstance(alert_.last_modified, datetime.datetime)
+
+
+@pytest.mark.httpretty
+def test_alert_filter(connection, alert, alert_payload):
+    """Verifies alert listing and filtering."""
+    httpretty.register_uri(
+        httpretty.GET, '{}/alerts'.format(matchlight.MATCHLIGHT_API_URL_V2),
+        body=json.dumps({'data': [alert_payload]}),
+        content_type='application/json',
+        status=200
+    )
+    alerts = connection.alerts.filter()
+    assert len(alerts) == 1
+    assert alerts[0].id == alert.id
+
+
+@pytest.mark.httpretty
+def test_alert_filter_seen(connection, alert, alert_payload):
+    """Verifies alert filtering on 'seen'."""
+    # Create opposite alert
+    unseen_payload = alert_payload.copy()
+    unseen_payload['seen'] = 'false'
+    unseen_payload['id'] = str(uuid.uuid4())
+
+    # Get seen alerts
+    httpretty.register_uri(
+        httpretty.GET, '{}/alerts?seen=1'.format(
+            matchlight.MATCHLIGHT_API_URL_V2
+        ),
+        body=json.dumps({'data': [alert_payload]}),
+        content_type='application/json',
+        status=200
+    )
+
+    alerts = connection.alerts.filter(seen=True)
+    assert len(alerts) == 1
+    assert alerts[0].id == alert_payload['id']
+
+    # Get unseen alerts
+    httpretty.register_uri(
+        httpretty.GET, '{}/alerts?seen=0'.format(
+            matchlight.MATCHLIGHT_API_URL_V2
+        ),
+        body=json.dumps({'data': [unseen_payload]}),
+        content_type='application/json',
+        status=200
+    )
+
+    alerts = connection.alerts.filter(seen=False)
+    assert len(alerts) == 1
+    assert alerts[0].id == unseen_payload['id']
+
+
+@pytest.mark.httpretty
+def test_alert_filter_archived(connection, alert, alert_payload):
+    """Verifies alert filtering on 'archived'."""
+    # Create opposite alert
+    unarchived_payload = alert_payload.copy()
+    unarchived_payload['archived'] = 'false'
+    unarchived_payload['id'] = str(uuid.uuid4())
+
+    # Get archived alerts
+    httpretty.register_uri(
+        httpretty.GET, '{}/alerts?archived=1'.format(
+            matchlight.MATCHLIGHT_API_URL_V2
+        ),
+        body=json.dumps({'data': [alert_payload]}),
+        content_type='application/json',
+        status=200
+    )
+
+    alerts = connection.alerts.filter(archived=True)
+    assert len(alerts) == 1
+    assert alerts[0].id == alert_payload['id']
+
+    # Get unarchived alerts
+    httpretty.register_uri(
+        httpretty.GET, '{}/alerts?archived=0'.format(
+            matchlight.MATCHLIGHT_API_URL_V2
+        ),
+        body=json.dumps({'data': [unarchived_payload]}),
+        content_type='application/json',
+        status=200
+    )
+
+    alerts = connection.alerts.filter(archived=False)
+    assert len(alerts) == 1
+    assert alerts[0].id == unarchived_payload['id']
+
+
+@pytest.mark.httpretty
+def test_alert_filter_project(connection, alert, alert_payload, project):
+    """Verifies alert filtering on 'upload_token'."""
+    httpretty.register_uri(
+        httpretty.GET, '{}/alerts?upload_token={}'.format(
+            matchlight.MATCHLIGHT_API_URL_V2,
+            project.upload_token
+        ),
+        body=json.dumps({'data': [alert_payload]}),
+        content_type='application/json',
+        status=200
+    )
+
+    alerts = connection.alerts.filter(project=project)
+    assert len(alerts) == 1
+    assert alerts[0].id == alert_payload['id']
+
+
+@pytest.mark.httpretty
+def test_alert_all(connection, alert, alert_payload):
+    """Verifies alert listing and filtering."""
+    httpretty.register_uri(
+        httpretty.GET, '{}/alerts'.format(matchlight.MATCHLIGHT_API_URL_V2),
+        body=json.dumps({'data': [alert_payload]}),
+        content_type='application/json',
+        status=200
+    )
+    alerts = connection.alerts.all()
+    assert len(alerts) == 1
+    assert alerts[0].id == alert.id
+
+
+@pytest.mark.httpretty
+def test_alert_iteration(connection, alert, alert_payload):
+    """Verifies alert iteration."""
+    httpretty.register_uri(
+        httpretty.GET, '{}/alerts'.format(matchlight.MATCHLIGHT_API_URL_V2),
+        body=json.dumps({'data': [alert_payload]}),
+        content_type='application/json',
+        status=200,
+    )
+    alerts_iterable = iter(connection.alerts)
+    assert next(alerts_iterable).id == alert.id
+    with pytest.raises(StopIteration):
+        next(alerts_iterable)

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -208,8 +208,8 @@ def test_alert_edit(connection, alert, alert_payload):
             alert.id,
         ),
         body=json.dumps({
-            'archived': 'true',
-            'seen': 'true'
+            'archived': True,
+            'seen': True
         }),
         status=200
     )
@@ -224,8 +224,8 @@ def test_alert_edit(connection, alert, alert_payload):
             alert.id,
         ),
         body=json.dumps({
-            'archived': 'false',
-            'seen': 'true'
+            'archived': False,
+            'seen': True
         }),
         status=200
     )
@@ -240,8 +240,8 @@ def test_alert_edit(connection, alert, alert_payload):
             alert.id,
         ),
         body=json.dumps({
-            'archived': 'false',
-            'seen': 'false'
+            'archived': False,
+            'seen': False
         }),
         status=200
     )
@@ -256,8 +256,8 @@ def test_alert_edit(connection, alert, alert_payload):
             alert.id,
         ),
         body=json.dumps({
-            'archived': 'true',
-            'seen': 'true'
+            'archived': True,
+            'seen': True
         }),
         status=200
     )

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -14,12 +14,14 @@ import matchlight
 def test_alert_dates(connection, alert, alert_payload):
     """Verifies alert date objects are converted correctly."""
     httpretty.register_uri(
-        httpretty.GET, '{}/alerts'.format(matchlight.MATCHLIGHT_API_URL_V2),
-        body=json.dumps({'data': [alert_payload]}),
+        httpretty.GET, '{}/alerts?limit=50'.format(
+            matchlight.MATCHLIGHT_API_URL_V2
+        ),
+        body=json.dumps({'alerts': [alert_payload]}),
         content_type='application/json',
         status=200
     )
-    alerts = connection.alerts.filter()
+    alerts = connection.alerts.filter(limit=50)
     assert isinstance(alerts[0].date, datetime.datetime)
     assert isinstance(alerts[0].last_modified, datetime.datetime)
 
@@ -28,12 +30,14 @@ def test_alert_dates(connection, alert, alert_payload):
 def test_alert_filter(connection, alert, alert_payload):
     """Verifies alert listing and filtering."""
     httpretty.register_uri(
-        httpretty.GET, '{}/alerts'.format(matchlight.MATCHLIGHT_API_URL_V2),
-        body=json.dumps({'data': [alert_payload]}),
+        httpretty.GET, '{}/alerts?limit=50'.format(
+            matchlight.MATCHLIGHT_API_URL_V2
+        ),
+        body=json.dumps({'alerts': [alert_payload]}),
         content_type='application/json',
         status=200
     )
-    alerts = connection.alerts.filter()
+    alerts = connection.alerts.filter(limit=50)
     assert len(alerts) == 1
     assert alerts[0].id == alert.id
 
@@ -48,29 +52,29 @@ def test_alert_filter_seen(connection, alert, alert_payload):
 
     # Get seen alerts
     httpretty.register_uri(
-        httpretty.GET, '{}/alerts?seen=1'.format(
+        httpretty.GET, '{}/alerts?seen=1&limit=50'.format(
             matchlight.MATCHLIGHT_API_URL_V2
         ),
-        body=json.dumps({'data': [alert_payload]}),
+        body=json.dumps({'alerts': [alert_payload]}),
         content_type='application/json',
         status=200
     )
 
-    alerts = connection.alerts.filter(seen=True)
+    alerts = connection.alerts.filter(limit=50, seen=True)
     assert len(alerts) == 1
     assert alerts[0].id == alert_payload['id']
 
     # Get unseen alerts
     httpretty.register_uri(
-        httpretty.GET, '{}/alerts?seen=0'.format(
+        httpretty.GET, '{}/alerts?seen=0&limit=50'.format(
             matchlight.MATCHLIGHT_API_URL_V2
         ),
-        body=json.dumps({'data': [unseen_payload]}),
+        body=json.dumps({'alerts': [unseen_payload]}),
         content_type='application/json',
         status=200
     )
 
-    alerts = connection.alerts.filter(seen=False)
+    alerts = connection.alerts.filter(limit=50, seen=False)
     assert len(alerts) == 1
     assert alerts[0].id == unseen_payload['id']
 
@@ -85,29 +89,29 @@ def test_alert_filter_archived(connection, alert, alert_payload):
 
     # Get archived alerts
     httpretty.register_uri(
-        httpretty.GET, '{}/alerts?archived=1'.format(
+        httpretty.GET, '{}/alerts?archived=1&limit=50'.format(
             matchlight.MATCHLIGHT_API_URL_V2
         ),
-        body=json.dumps({'data': [alert_payload]}),
+        body=json.dumps({'alerts': [alert_payload]}),
         content_type='application/json',
         status=200
     )
 
-    alerts = connection.alerts.filter(archived=True)
+    alerts = connection.alerts.filter(limit=50, archived=True)
     assert len(alerts) == 1
     assert alerts[0].id == alert_payload['id']
 
     # Get unarchived alerts
     httpretty.register_uri(
-        httpretty.GET, '{}/alerts?archived=0'.format(
+        httpretty.GET, '{}/alerts?archived=0&limit=50'.format(
             matchlight.MATCHLIGHT_API_URL_V2
         ),
-        body=json.dumps({'data': [unarchived_payload]}),
+        body=json.dumps({'alerts': [unarchived_payload]}),
         content_type='application/json',
         status=200
     )
 
-    alerts = connection.alerts.filter(archived=False)
+    alerts = connection.alerts.filter(limit=50, archived=False)
     assert len(alerts) == 1
     assert alerts[0].id == unarchived_payload['id']
 
@@ -116,16 +120,16 @@ def test_alert_filter_archived(connection, alert, alert_payload):
 def test_alert_filter_project(connection, alert, alert_payload, project):
     """Verifies alert filtering on 'upload_token'."""
     httpretty.register_uri(
-        httpretty.GET, '{}/alerts?upload_token_filter={}'.format(
+        httpretty.GET, '{}/alerts?upload_token_filter={}&limit=50'.format(
             matchlight.MATCHLIGHT_API_URL_V2,
             project.upload_token
         ),
-        body=json.dumps({'data': [alert_payload]}),
+        body=json.dumps({'alerts': [alert_payload]}),
         content_type='application/json',
         status=200
     )
 
-    alerts = connection.alerts.filter(project=project)
+    alerts = connection.alerts.filter(limit=50, project=project)
     assert len(alerts) == 1
     assert alerts[0].id == alert_payload['id']
 
@@ -135,16 +139,16 @@ def test_alert_filter_record(connection, alert, alert_payload,
                              document_record):
     """Verifies alert filtering on 'record_id'."""
     httpretty.register_uri(
-        httpretty.GET, '{}/alerts?record_id_filter={}'.format(
+        httpretty.GET, '{}/alerts?record_id_filter={}&limit=50'.format(
             matchlight.MATCHLIGHT_API_URL_V2,
             document_record.id
         ),
-        body=json.dumps({'data': [alert_payload]}),
+        body=json.dumps({'alerts': [alert_payload]}),
         content_type='application/json',
         status=200
     )
 
-    alerts = connection.alerts.filter(record=document_record)
+    alerts = connection.alerts.filter(limit=50, record=document_record)
     assert len(alerts) == 1
     assert alerts[0].id == alert_payload['id']
 
@@ -160,65 +164,38 @@ def test_alert_filter_mtime(connection, alert, alert_payload):
 
     # Get all alerts
     httpretty.register_uri(
-        httpretty.GET, '{}/alerts?mtime={}'.format(
+        httpretty.GET, '{}/alerts?mtime={}&limit=50'.format(
             matchlight.MATCHLIGHT_API_URL_V2,
             now - 259200
         ),
-        body=json.dumps({'data': [alert_payload, old_payload]}),
+        body=json.dumps({'alerts': [alert_payload, old_payload]}),
         content_type='application/json',
         status=200
     )
 
     alerts = connection.alerts.filter(
+        limit=50,
         last_modified=datetime.datetime.fromtimestamp(now - 259200)
     )
     assert len(alerts) == 2
 
     # Get new alerts
     httpretty.register_uri(
-        httpretty.GET, '{}/alerts?mtime={}'.format(
+        httpretty.GET, '{}/alerts?mtime={}&limit=50'.format(
             matchlight.MATCHLIGHT_API_URL_V2,
             now - 86400
         ),
-        body=json.dumps({'data': [alert_payload]}),
+        body=json.dumps({'alerts': [alert_payload]}),
         content_type='application/json',
         status=200
     )
 
     alerts = connection.alerts.filter(
+        limit=50,
         last_modified=datetime.datetime.fromtimestamp(now - 86400)
     )
     assert len(alerts) == 1
     assert alerts[0].id == alert_payload['id']
-
-
-@pytest.mark.httpretty
-def test_alert_all(connection, alert, alert_payload):
-    """Verifies alert listing and filtering."""
-    httpretty.register_uri(
-        httpretty.GET, '{}/alerts'.format(matchlight.MATCHLIGHT_API_URL_V2),
-        body=json.dumps({'data': [alert_payload]}),
-        content_type='application/json',
-        status=200
-    )
-    alerts = connection.alerts.all()
-    assert len(alerts) == 1
-    assert alerts[0].id == alert.id
-
-
-@pytest.mark.httpretty
-def test_alert_iteration(connection, alert, alert_payload):
-    """Verifies alert iteration."""
-    httpretty.register_uri(
-        httpretty.GET, '{}/alerts'.format(matchlight.MATCHLIGHT_API_URL_V2),
-        body=json.dumps({'data': [alert_payload]}),
-        content_type='application/json',
-        status=200,
-    )
-    alerts_iterable = iter(connection.alerts)
-    assert next(alerts_iterable).id == alert.id
-    with pytest.raises(StopIteration):
-        next(alerts_iterable)
 
 
 @pytest.mark.httpretty

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -55,19 +55,6 @@ PII_RECORDS_RAW_PATH = 'tests/fixtures/pii_records_raw.json'
 #     phone = factory.LazyAttribute(lambda _: fake.phone_number())
 
 
-@pytest.fixture(scope='function')
-def document(request):
-    """A document record fixture."""
-    return {
-        'id': uuid.uuid4().hex,
-        'name': 'Document record',
-        'description': '',
-        'ctime': time.time(),
-        'mtime': time.time(),
-        'metadata': {},
-    }
-
-
 @pytest.fixture(scope='function', params=[PII_RECORDS_RAW_PATH])
 def pii_records_raw(request):
     """Sample PII records."""


### PR DESCRIPTION
Allows for fetching & editing of Matchlight Alerts with the SDK.

Somewhat less features than Projects and Records because of the API limitations. Mostly the lack of an endpoint to get a specific alert.
'limit' is a required parameter when fetching alerts to make that explicit, since the API will limit to 50 if that parameter is not provided.