### PR TITLE
Allow getting feeds by name

### DIFF
--- a/src/matchlight/feed.py
+++ b/src/matchlight/feed.py
@@ -125,7 +125,7 @@ class FeedMethods(object):
         """Daily counts for a feed for a given date range.
 
         Args:
-            feed (:class:`~.Feed`): A feed instance.
+            feed (:class:`~.Feed`): A feed instance or feed name.
             start_date (:class:`datetime.datetime`): Start of date range.
             end_date (:class:`datetime.datetime`): End of date range.
 
@@ -133,12 +133,17 @@ class FeedMethods(object):
             :obj:`dict`: Mapping of dates (``YYYY-MM-DD``) to alert counts.
 
         """
+        if isinstance(feed, six.string_types):
+            feed_name = feed
+        else:
+            feed_name = feed.name
+
         data = {
             'start_date': int(matchlight.utils.datetime_to_unix(start_date)),
             'end_date': int(matchlight.utils.datetime_to_unix(end_date)),
         }
         response = self.conn.request(
-            '/feeds/{feed_name}'.format(feed_name=feed.name),
+            '/feeds/{feed_name}'.format(feed_name=feed_name),
             data=json.dumps(data))
         return self._format_count(response.json())
 
@@ -146,7 +151,7 @@ class FeedMethods(object):
         """Downloads feed data for the given date range.
 
         Args:
-            feed (:class:`~.Feed`): A feed instance.
+            feed (:class:`~.Feed`): A feed instance or feed name.
             start_date (:class:`datetime.datetime`): Start of date range.
             end_date (:class:`datetime.datetime`): End of date range.
             save_path (:obj:`str`): Path to output file.
@@ -155,12 +160,17 @@ class FeedMethods(object):
             :obj:`list` of :obj:`dict`: All feed hits for the given range.
 
         """
+        if isinstance(feed, six.string_types):
+            feed_name = feed
+        else:
+            feed_name = feed.name
+
         data = {
             'start_date': int(matchlight.utils.datetime_to_unix(start_date)),
             'end_date': int(matchlight.utils.datetime_to_unix(end_date)),
         }
         response = self.conn.request(
-            '/feed/{feed_name}/prepare'.format(feed_name=feed.name),
+            '/feed/{feed_name}/prepare'.format(feed_name=feed_name),
             data=json.dumps(data))
 
         if response.status_code != 200:
@@ -172,7 +182,7 @@ class FeedMethods(object):
         status = 'pending'
         while status == 'pending':
             response = self.conn.request(
-                '/feed/{feed_name}/link'.format(feed_name=feed.name),
+                '/feed/{feed_name}/link'.format(feed_name=feed_name),
                 data=json.dumps(data))
             status = response.json().get('status', None)
             time.sleep(1)

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -126,6 +126,9 @@ def test_feed_counts(connection, feed, start_time, end_time):
     result = connection.feeds.counts(feed, start_time, end_time)
     assert result == connection.feeds._format_count(expected)
 
+    result = connection.feeds.counts(feed.name, start_time, end_time)
+    assert result == connection.feeds._format_count(expected)
+
 
 @pytest.mark.httpretty
 def test_feed_download(connection, feed, start_time, end_time,
@@ -162,6 +165,13 @@ def test_feed_download(connection, feed, start_time, end_time,
         content_type='text/csv',
         body='\n'.join(feed_report_csv))
     rows = connection.feeds.download(feed, start_time, end_time)
+    feed_rows = [
+        connection.feeds._format_feed(row)
+        for row in csv.DictReader(feed_report_csv)
+    ]
+    assert rows == feed_rows
+
+    rows = connection.feeds.download(feed.name, start_time, end_time)
     feed_rows = [
         connection.feeds._format_feed(row)
         for row in csv.DictReader(feed_report_csv)


### PR DESCRIPTION
Feed methods no longer need a feed object passed in, a string will work.