### PR TITLE
Fix for uploading PII records without a middle name

### DIFF
--- a/src/matchlight/record.py
+++ b/src/matchlight/record.py
@@ -200,7 +200,7 @@ class RecordMethods(object):
 
         if any((first_name, middle_name, last_name)):
             name_fingerprints = fingerprints_pii_name_variants(
-                first_name or '', middle_name or '', last_name or '')
+                first_name or '', middle_name or None, last_name or '')
             data['name_fingerprints'] = name_fingerprints
 
         if email is not None:


### PR DESCRIPTION
LibFP expects blank values to be None, an empty string for any of the fields returns no name fingerprints. This is desired for "first_name" and "last_name" as both are required to create enough fingerprints to be useful. But "middle_name" should not be required.