### PR TITLE
Bugfix: project add return value

### DIFF
--- a/src/matchlight/project.py
+++ b/src/matchlight/project.py
@@ -168,7 +168,7 @@ class ProjectMethods(collections_abc.Iterable):
         """
         data = json.dumps({'name': name, 'type': project_type})
         r = self.conn.request('/project/add', data=data)
-        return Project.from_mapping(r.json()["data"])
+        return Project.from_mapping(r.json()['data'])
 
     def delete(self, project):
         """Deletes a project and all associated records.

--- a/src/matchlight/project.py
+++ b/src/matchlight/project.py
@@ -168,7 +168,7 @@ class ProjectMethods(collections_abc.Iterable):
         """
         data = json.dumps({'name': name, 'type': project_type})
         r = self.conn.request('/project/add', data=data)
-        return self.get(r.json()['data'].get('project_upload_token'))
+        return Project.from_mapping(r.json()["data"])
 
     def delete(self, project):
         """Deletes a project and all associated records.

--- a/src/matchlight/project.py
+++ b/src/matchlight/project.py
@@ -168,7 +168,7 @@ class ProjectMethods(collections_abc.Iterable):
         """
         data = json.dumps({'name': name, 'type': project_type})
         r = self.conn.request('/project/add', data=data)
-        return self.get(r.json()['data'].get('upload_token'))
+        return self.get(r.json()['data'].get('project_upload_token'))
 
     def delete(self, project):
         """Deletes a project and all associated records.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -25,14 +25,7 @@ def test_project_add(connection, project_name, project_payload,
     httpretty.register_uri(
         httpretty.POST, '{}/project/add'.format(
             matchlight.MATCHLIGHT_API_URL_V2),
-        body=json.dumps({'data': {'upload_token': upload_token}}),
-        content_type='application/json', status=200)
-    httpretty.register_uri(
-        httpretty.GET, '{}/project/{}'.format(
-            matchlight.MATCHLIGHT_API_URL_V2,
-            upload_token,
-        ),
-        body=json.dumps(project_payload),
+        body=json.dumps({'data': project_payload}),
         content_type='application/json', status=200)
     project = connection.projects.add(project_name, project_type)
     assert project.upload_token == upload_token


### PR DESCRIPTION
First off, the `/api/v2/project/add` endpoint returns "project_upload_token", not "upload_token", so the `Connection.projects.add` method always returns `None` since it wasn't pulling in the right value.  I then realized that the add endpoint returns the serialized project in full, so there's no need to re-fetch the project details.