### PR TITLE
Set all request timeouts to just over API timeout

### DIFF
--- a/src/matchlight/connection.py
+++ b/src/matchlight/connection.py
@@ -104,7 +104,8 @@ class Connection(object):
 
         method = 'GET' if data is None else 'POST'
         if 'timeout' not in kwargs:
-            kwargs['timeout'] = 5.0
+            # API timeout is 90s
+            kwargs['timeout'] = 91.0
 
         response = self._request(
             method,

--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -89,7 +89,7 @@ class SearchMethods(object):
             '/detailed_search',
             data=json.dumps(data),
             endpoint=self.conn.search_endpoint,
-            timeout=90.0)
+        )
         try:
             results = response.json()['results']
         except KeyError:


### PR DESCRIPTION
The timeout of the API is 90s. If the request timeout is shorter, a request may error out in the client but complete successfully on the server. This is confusing and may cause problems if the client tries again.