### PR TITLE
Drop Python 3.3 support, Add 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ matrix:
       env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
     - python: 3.5
       env: TOXENV=flake8

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYENVS=2.7.15 3.3.7 3.4.8 3.5.5 3.6.5
+PYENVS=2.7.15 3.4.8 3.5.5 3.6.5
 REQUIREMENTS_DIR=requirements
 
 .PHONY: clean clean_wheels

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYENVS=2.7.11 3.3.6 3.4.3 3.5.0
+PYENVS=2.7.15 3.3.7 3.4.8 3.5.5 3.6.5
 REQUIREMENTS_DIR=requirements
 
 .PHONY: clean clean_wheels

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ application-import-names = matchlight, pylibfp
 
 [tox]
 minversion=2.3.1
-envlist = {py27,py34,py35,py36}-wheel31, py33-wheel29, flake8, doc8, bandit
+envlist = py27,py34,py35,py36,flake8,doc8,bandit
 
 [testenv]
 deps =
@@ -79,8 +79,7 @@ commands =
 basepython = python3.6
 skip_install = true
 deps =
-  wheel29: wheel>=0.29,<0.30
-  wheel31: wheel>=0.31,<0.32
+  wheel
   setuptools
 commands =
   python setup.py -q sdist bdist_wheel

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
 
 # Linters
 [testenv:flake8]
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
   -r{toxinidir}/requirements/dev.txt
@@ -40,7 +40,7 @@ commands =
   flake8 src/matchlight tests/ setup.py
 
 [testenv:doc8]
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
   sphinx
@@ -49,7 +49,7 @@ commands =
   doc8 docs/source
 
 [testenv:bandit]
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
   bandit
@@ -58,7 +58,7 @@ commands =
 
 # Documentation
 [testenv:docs]
-basepython = python3.6
+basepython = python3
 deps =
   setuptools_scm
   sphinx>=1.3.0
@@ -67,7 +67,7 @@ commands =
 
 
 [testenv:serve-docs]
-basepython = python3.6
+basepython = python3
 skip_install = true
 changedir = docs/build/html
 deps =
@@ -76,7 +76,7 @@ commands =
 
 # Release
 [testenv:build]
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
   wheel
@@ -85,7 +85,7 @@ commands =
   python setup.py -q sdist bdist_wheel
 
 [testenv:release]
-basepython = python3.6
+basepython = python3
 skip_install = true
 deps =
   {[testenv:build]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ application-import-names = matchlight, pylibfp
 
 [tox]
 minversion=2.3.1
-envlist = py27,py33,py34,py35,py36,flake8,doc8,bandit
+envlist = {py27,py34,py35,py36}-wheel31, py33-wheel29, flake8, doc8, bandit
 
 [testenv]
 deps =
@@ -32,7 +32,7 @@ commands =
 
 # Linters
 [testenv:flake8]
-basepython = python3
+basepython = python3.6
 skip_install = true
 deps =
   -r{toxinidir}/requirements/dev.txt
@@ -40,7 +40,7 @@ commands =
   flake8 src/matchlight tests/ setup.py
 
 [testenv:doc8]
-basepython = python3
+basepython = python3.6
 skip_install = true
 deps =
   sphinx
@@ -49,7 +49,7 @@ commands =
   doc8 docs/source
 
 [testenv:bandit]
-basepython = python3
+basepython = python3.6
 skip_install = true
 deps =
   bandit
@@ -58,7 +58,7 @@ commands =
 
 # Documentation
 [testenv:docs]
-basepython = python3
+basepython = python3.6
 deps =
   setuptools_scm
   sphinx>=1.3.0
@@ -67,7 +67,7 @@ commands =
 
 
 [testenv:serve-docs]
-basepython = python3
+basepython = python3.6
 skip_install = true
 changedir = docs/build/html
 deps =
@@ -76,16 +76,17 @@ commands =
 
 # Release
 [testenv:build]
-basepython = python3
+basepython = python3.6
 skip_install = true
 deps =
-  wheel==0.29.0
+  wheel29: wheel>=0.29,<0.30
+  wheel31: wheel>=0.31,<0.32
   setuptools
 commands =
   python setup.py -q sdist bdist_wheel
 
 [testenv:release]
-basepython = python3
+basepython = python3.6
 skip_install = true
 deps =
   {[testenv:build]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ application-import-names = matchlight, pylibfp
 
 [tox]
 minversion=2.3.1
-envlist = py27,py33,py34,py35,flake8,doc8,bandit
+envlist = py27,py33,py34,py35,py36,flake8,doc8,bandit
 
 [testenv]
 deps =
@@ -79,7 +79,7 @@ commands =
 basepython = python3
 skip_install = true
 deps =
-  wheel
+  wheel==0.29.0
   setuptools
 commands =
   python setup.py -q sdist bdist_wheel


### PR DESCRIPTION
Support for version 3.3 has been dropped by Pypa projects, and we will support 2.7.