### PR TITLE
Have blind_email return string of min length 5

### DIFF
--- a/src/matchlight/utils.py
+++ b/src/matchlight/utils.py
@@ -21,7 +21,7 @@ def blind_name(name, width=5):
 def blind_email(email):
     """Censors an email address."""
     if not email:
-        return '****'
+        return '*****'
     if '@' in email:
         prefix, suffix = email.split('@', 1)
         suffix = '@' + suffix

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+"""Unit tests the utils module of Matchlight SDK."""
+import matchlight
+
+
+def test_blind_name():
+    """Verify test cases for blind_name."""
+    test_cases = [
+        (None, '*****'),
+        ('', '*****'),
+        ('a', 'a****'),
+        ('foobar', 'f****'),
+        ('terbiumlabs', 't****'),
+    ]
+    for case, expected in test_cases:
+        assert matchlight.utils.blind_name(case) == expected
+
+
+def test_blind_email():
+    """Verify test cases for blind_email."""
+    test_cases = [
+        (None, '*****'),
+        ('', '*****'),
+        ('a@terbiumlabs.com', 'a****@terbiumlabs.com'),
+        ('ab@terbiumlabs.com', 'a****@terbiumlabs.com'),
+        ('abc@terbiumlabs.com', 'a****@terbiumlabs.com'),
+        ('abcd@terbiumlabs.com', 'ab****@terbiumlabs.com'),
+        ('abcde@terbiumlabs.com', 'ab****@terbiumlabs.com'),
+        ('abcdef@terbiumlabs.com', 'abc****@terbiumlabs.com'),
+        ('abcdefg@terbiumlabs.com', 'abc****@terbiumlabs.com'),
+        ('abcdefgh@terbiumlabs.com', 'abc****@terbiumlabs.com'),
+    ]
+    for case, expected in test_cases:
+        assert matchlight.utils.blind_email(case) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,33 +1,33 @@
 """Unit tests the utils module of Matchlight SDK."""
+import pytest
+
 import matchlight
 
 
-def test_blind_name():
+@pytest.mark.parametrize('test_input,expected', [
+    (None, '*****'),
+    ('', '*****'),
+    ('a', 'a****'),
+    ('foobar', 'f****'),
+    ('terbiumlabs', 't****'),
+])
+def test_blind_name(test_input, expected):
     """Verify test cases for blind_name."""
-    test_cases = [
-        (None, '*****'),
-        ('', '*****'),
-        ('a', 'a****'),
-        ('foobar', 'f****'),
-        ('terbiumlabs', 't****'),
-    ]
-    for case, expected in test_cases:
-        assert matchlight.utils.blind_name(case) == expected
+    assert matchlight.utils.blind_name(test_input) == expected
 
 
-def test_blind_email():
+@pytest.mark.parametrize('test_input,expected', [
+    (None, '*****'),
+    ('', '*****'),
+    ('a@terbiumlabs.com', 'a****@terbiumlabs.com'),
+    ('ab@terbiumlabs.com', 'a****@terbiumlabs.com'),
+    ('abc@terbiumlabs.com', 'a****@terbiumlabs.com'),
+    ('abcd@terbiumlabs.com', 'ab****@terbiumlabs.com'),
+    ('abcde@terbiumlabs.com', 'ab****@terbiumlabs.com'),
+    ('abcdef@terbiumlabs.com', 'abc****@terbiumlabs.com'),
+    ('abcdefg@terbiumlabs.com', 'abc****@terbiumlabs.com'),
+    ('abcdefgh@terbiumlabs.com', 'abc****@terbiumlabs.com'),
+])
+def test_blind_email(test_input, expected):
     """Verify test cases for blind_email."""
-    test_cases = [
-        (None, '*****'),
-        ('', '*****'),
-        ('a@terbiumlabs.com', 'a****@terbiumlabs.com'),
-        ('ab@terbiumlabs.com', 'a****@terbiumlabs.com'),
-        ('abc@terbiumlabs.com', 'a****@terbiumlabs.com'),
-        ('abcd@terbiumlabs.com', 'ab****@terbiumlabs.com'),
-        ('abcde@terbiumlabs.com', 'ab****@terbiumlabs.com'),
-        ('abcdef@terbiumlabs.com', 'abc****@terbiumlabs.com'),
-        ('abcdefg@terbiumlabs.com', 'abc****@terbiumlabs.com'),
-        ('abcdefgh@terbiumlabs.com', 'abc****@terbiumlabs.com'),
-    ]
-    for case, expected in test_cases:
-        assert matchlight.utils.blind_email(case) == expected
+    assert matchlight.utils.blind_email(test_input) == expected


### PR DESCRIPTION
Fixes issue #30 

`matchlight.utils.blind_email` used to return a length 4 string on empty values, which was invalid in our api. This change fixes that, so that all blinded values are at least length 5, and adds tests to confirm such change.