### PR TITLE
Fix regular Search with the 'email' parameter

### DIFF
--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -104,7 +104,7 @@ class SearchMethods(object):
             for url in result['urls']:
                 yield {
                     'score': result['score'],
-                    'ts': datetime.datetime.fromtimestamp(url[0]),
+                    'ts': datetime.datetime.fromtimestamp(float(url[0])),
                     'url': url[1]
                 }
 
@@ -160,6 +160,6 @@ class SearchMethods(object):
                 result['ts'],
                 '%Y-%m-%dT%H:%M:%S'
             ) if isinstance(result['ts'], str) else (
-                datetime.datetime.fromtimestamp(result['ts'])
+                datetime.datetime.fromtimestamp(float(result['ts']))
             )
             yield result

--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -86,7 +86,9 @@ class SearchMethods(object):
                 yield(x)
             else:
                 for i in x:
-                    yield from flatten_iter(i)
+                    # same as yield from flatten_iter(i)
+                    for j in flatten_iter(i):
+                        yield j
 
         data = {'fingerprints': list(flatten_iter(fingerprints))}
         response = self.conn.request(

--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -156,7 +156,7 @@ class SearchMethods(object):
             raise matchlight.error.SDKError('Failed to get search results')
         for result in results:
             # This result can seemingly be in different formats.
-            if isinstance(result['ts'], str):
+            if isinstance(result['ts'], (str, unicode)):
                 result['ts'] = datetime.datetime.strptime(
                     result['ts'],
                     '%Y-%m-%dT%H:%M:%S'

--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -153,8 +153,11 @@ class SearchMethods(object):
         except KeyError:
             raise matchlight.error.SDKError('Failed to get search results')
         for result in results:
+            # This result can seemingly be in two different formats.
             result['ts'] = datetime.datetime.strptime(
                 result['ts'],
                 '%Y-%m-%dT%H:%M:%S'
+            ) if isinstance(result['ts'], str) else (
+                datetime.datetime.fromtimestamp(result['ts'])
             )
             yield result

--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -80,11 +80,15 @@ class SearchMethods(object):
             result = json.loads(result_json)
             fingerprints = result['data']['fingerprints']
 
-        if any(isinstance(element, list) for element in fingerprints):
-            raise matchlight.error.SDKError(
-                'Fingerprinter Failed: List of Lists')
+        # We have to convert possible lists of lists to a flat list of strings
+        def flatten_iter(x):
+            if not isinstance(x, list):
+                yield(x)
+            else:
+                for i in x:
+                    yield from flatten_iter(i)
 
-        data = {'fingerprints': list(fingerprints)}
+        data = {'fingerprints': list(flatten_iter(fingerprints))}
         response = self.conn.request(
             '/detailed_search',
             data=json.dumps(data),

--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 import datetime
 import json
 
+import six
+
 import matchlight.error
 import pylibfp
 
@@ -156,7 +158,7 @@ class SearchMethods(object):
             raise matchlight.error.SDKError('Failed to get search results')
         for result in results:
             # This result can seemingly be in different formats.
-            if isinstance(result['ts'], (str, unicode)):
+            if isinstance(result['ts'], six.text_type):
                 result['ts'] = datetime.datetime.strptime(
                     result['ts'],
                     '%Y-%m-%dT%H:%M:%S'

--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -155,11 +155,15 @@ class SearchMethods(object):
         except KeyError:
             raise matchlight.error.SDKError('Failed to get search results')
         for result in results:
-            # This result can seemingly be in two different formats.
-            result['ts'] = datetime.datetime.strptime(
-                result['ts'],
-                '%Y-%m-%dT%H:%M:%S'
-            ) if isinstance(result['ts'], str) else (
-                datetime.datetime.fromtimestamp(float(result['ts']))
-            )
+            # This result can seemingly be in different formats.
+            if isinstance(result['ts'], str):
+                result['ts'] = datetime.datetime.strptime(
+                    result['ts'],
+                    '%Y-%m-%dT%H:%M:%S'
+                )
+            elif isinstance(result['ts'], int):
+                result['ts'] = datetime.datetime.fromtimestamp(
+                    float(result['ts'])
+                )
+
             yield result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,3 +175,38 @@ def pii_search_email_only_results():
             'source': 'https://www.reddit.com/r/AskReddit/comments/3oqj4a'
         },
     ]
+
+
+@pytest.fixture(scope='function')
+def search_email_only_results():
+    """PII search results for only the email field."""
+    return [
+        {
+            'cwid': 'fff33cbe7ed54f5ebfccd09c3d24999c',
+            'score': 800,
+            'ts': 1453298293,
+            'urls': [
+                [
+                    1453298293,
+                    (
+                        'http://blockchainbdgpzk.onion/tx/4f4097992b89156'
+                        '690817556fc3f540535bdfadde06661c9cae21d500943f970'
+                    )
+                ]
+            ]
+        },
+        {
+            'cwid': 'ffedf0a2b775cfd50383603ff827d702',
+            'score': 800,
+            'ts': 1438870917,
+            'urls': [
+                [
+                    1438870917,
+                    (
+                        'http://nqigfqrxnkwcqmiq.onion/'
+                        'wiki/index.php#Whistleblowing'
+                    )
+                ]
+            ]
+        },
+    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,12 +166,12 @@ def pii_search_email_only_results():
         },
         {
             'fields': ['email'],
-            'ts': '2017-02-08T07:59:39',
+            'ts': 1556221970,
             'source': 'Zoosk Breach Nov 2016'
         },
         {
             'fields': ['email'],
-            'ts': '2016-11-24T00:18:27',
+            'ts': 1558333205,
             'source': 'https://www.reddit.com/r/AskReddit/comments/3oqj4a'
         },
     ]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -38,12 +38,12 @@ def test_pii_search(connection, pii_search_email_only_results):
         },
         {
             'fields': ['email'],
-            'ts': datetime.datetime.fromtimestamp(1556221970),
+            'ts': datetime.datetime.fromtimestamp(1556221970.0),
             'source': 'Zoosk Breach Nov 2016'
         },
         {
             'fields': ['email'],
-            'ts': datetime.datetime.fromtimestamp(1558333205),
+            'ts': datetime.datetime.fromtimestamp(1558333205.0),
             'source': 'https://www.reddit.com/r/AskReddit/comments/3oqj4a'
         }
     ]
@@ -106,14 +106,14 @@ def test_search_email(connection, search_email_only_results):
     ) == [
         {
             'score': 800,
-            'ts': datetime.datetime.fromtimestamp(1453298293),
+            'ts': datetime.datetime.fromtimestamp(1453298293.0),
             'url': (
                 'http://blockchainbdgpzk.onion/tx/4f4097992b89156'
                 '690817556fc3f540535bdfadde06661c9cae21d500943f970'
             )
         }, {
             'score': 800,
-            'ts': datetime.datetime.fromtimestamp(1438870917),
+            'ts': datetime.datetime.fromtimestamp(1438870917.0),
             'url': (
                 'http://nqigfqrxnkwcqmiq.onion/'
                 'wiki/index.php#Whistleblowing'

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -89,8 +89,6 @@ def test_search_email(connection, search_email_only_results):
         status=200
     )
 
-    print(list(connection.search(email='familybird@terbiumlabs.com')))
-
     assert list(
         connection.search(email='familybird@terbiumlabs.com')
     ) == [

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -77,3 +77,36 @@ def test_pii_search_limit(connection, pii_search_email_only_results):
         'email_fingerprints': [['ff71225ace46c2b0'], ['293de73a18a5e063']],
         'limit': 2,
     }
+
+
+@responses.activate
+def test_search_email(connection, search_email_only_results):
+    """Verifies generic search when using email."""
+    responses.add(
+        method=responses.POST,
+        url='{}/detailed_search'.format(matchlight.MATCHLIGHT_API_URL_V2),
+        json={'results': search_email_only_results},
+        status=200
+    )
+
+    print(list(connection.search(email='familybird@terbiumlabs.com')))
+
+    assert list(
+        connection.search(email='familybird@terbiumlabs.com')
+    ) == [
+        {
+            'score': 800,
+            'ts': datetime.datetime(2016, 1, 20, 8, 58, 13),
+            'url': (
+                'http://blockchainbdgpzk.onion/tx/4f4097992b89156'
+                '690817556fc3f540535bdfadde06661c9cae21d500943f970'
+            )
+        }, {
+            'score': 800,
+            'ts': datetime.datetime(2015, 8, 6, 10, 21, 57),
+            'url': (
+                'http://nqigfqrxnkwcqmiq.onion/'
+                'wiki/index.php#Whistleblowing'
+            )
+        }
+    ]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -22,12 +22,18 @@ def test_pii_search(connection, pii_search_email_only_results):
     ) == [
         {
             'fields': ['email'],
-            'ts': datetime.datetime.fromtimestamp(1532563244),
+            'ts': datetime.datetime.strptime(
+                '2018-07-25T20:00:44',
+                '%Y-%m-%dT%H:%M:%S'
+            ),
             'source': 'Exactis Breach June 2018'
         },
         {
             'fields': ['email'],
-            'ts': datetime.datetime.fromtimestamp(1485329704),
+            'ts': datetime.datetime.strptime(
+                '2017-01-25T02:35:04',
+                '%Y-%m-%dT%H:%M:%S'
+            ),
             'source': 'https://pastebin.com/raw.php?i=1DgbtSZc'
         },
         {
@@ -63,12 +69,18 @@ def test_pii_search_limit(connection, pii_search_email_only_results):
     ) == [
         {
             'fields': ['email'],
-            'ts': datetime.datetime.fromtimestamp(1532563244),
+            'ts': datetime.datetime.strptime(
+                '2018-07-25T20:00:44',
+                '%Y-%m-%dT%H:%M:%S'
+            ),
             'source': 'Exactis Breach June 2018'
         },
         {
             'fields': ['email'],
-            'ts': datetime.datetime.fromtimestamp(1485329704),
+            'ts': datetime.datetime.strptime(
+                '2017-01-25T02:35:04',
+                '%Y-%m-%dT%H:%M:%S'
+            ),
             'source': 'https://pastebin.com/raw.php?i=1DgbtSZc'
         }
     ]
@@ -94,14 +106,14 @@ def test_search_email(connection, search_email_only_results):
     ) == [
         {
             'score': 800,
-            'ts': datetime.datetime(2016, 1, 20, 8, 58, 13),
+            'ts': datetime.datetime.fromtimestamp(1453298293),
             'url': (
                 'http://blockchainbdgpzk.onion/tx/4f4097992b89156'
                 '690817556fc3f540535bdfadde06661c9cae21d500943f970'
             )
         }, {
             'score': 800,
-            'ts': datetime.datetime(2015, 8, 6, 10, 21, 57),
+            'ts': datetime.datetime.fromtimestamp(1438870917),
             'url': (
                 'http://nqigfqrxnkwcqmiq.onion/'
                 'wiki/index.php#Whistleblowing'

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -32,12 +32,12 @@ def test_pii_search(connection, pii_search_email_only_results):
         },
         {
             'fields': ['email'],
-            'ts': datetime.datetime(2017, 2, 8, 7, 59, 39),
+            'ts': datetime.datetime(2019, 4, 25, 15, 52, 50),
             'source': 'Zoosk Breach Nov 2016'
         },
         {
             'fields': ['email'],
-            'ts': datetime.datetime(2016, 11, 24, 0, 18, 27),
+            'ts': datetime.datetime(2019, 5, 20, 2, 20, 5),
             'source': 'https://www.reddit.com/r/AskReddit/comments/3oqj4a'
         }
     ]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -22,22 +22,22 @@ def test_pii_search(connection, pii_search_email_only_results):
     ) == [
         {
             'fields': ['email'],
-            'ts': datetime.datetime(2018, 7, 25, 20, 0, 44),
+            'ts': datetime.datetime.fromtimestamp(1532563244),
             'source': 'Exactis Breach June 2018'
         },
         {
             'fields': ['email'],
-            'ts': datetime.datetime(2017, 1, 25, 2, 35, 4),
+            'ts': datetime.datetime.fromtimestamp(1485329704),
             'source': 'https://pastebin.com/raw.php?i=1DgbtSZc'
         },
         {
             'fields': ['email'],
-            'ts': datetime.datetime(2019, 4, 25, 15, 52, 50),
+            'ts': datetime.datetime.fromtimestamp(1556221970),
             'source': 'Zoosk Breach Nov 2016'
         },
         {
             'fields': ['email'],
-            'ts': datetime.datetime(2019, 5, 20, 2, 20, 5),
+            'ts': datetime.datetime.fromtimestamp(1558333205),
             'source': 'https://www.reddit.com/r/AskReddit/comments/3oqj4a'
         }
     ]
@@ -63,12 +63,12 @@ def test_pii_search_limit(connection, pii_search_email_only_results):
     ) == [
         {
             'fields': ['email'],
-            'ts': datetime.datetime(2018, 7, 25, 20, 0, 44),
+            'ts': datetime.datetime.fromtimestamp(1532563244),
             'source': 'Exactis Breach June 2018'
         },
         {
             'fields': ['email'],
-            'ts': datetime.datetime(2017, 1, 25, 2, 35, 4),
+            'ts': datetime.datetime.fromtimestamp(1485329704),
             'source': 'https://pastebin.com/raw.php?i=1DgbtSZc'
         }
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
   # https://github.com/gabrielfalcao/HTTPretty/issues/242
   ndg-httpsclient==0.3.0
 commands =
-  py.test --cov-config={toxinidir}/.coveragerc \
+  py.test -vv --cov-config={toxinidir}/.coveragerc \
     --cov={envsitepackagesdir}/matchlight \
     --cov-report=html \
     --cov-report=term-missing \


### PR DESCRIPTION
The regular search method `search`, **not** `pii_search` was returning errors now that we are generating variants for email addresses correctly. This addresses that by flattening the fingerprints lists before searching.