### PR TITLE
Fix indentation error in readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,7 @@ To run tests, install test requirements::
 
 You will also need to install Pyenv https://github.com/pyenv/pyenv#installation
 The easiest way is with Homebrew::
+
     $ brew update
     $ brew install pyenv
 


### PR DESCRIPTION
When I tried to publish the latest version to PyPI, I was greeted with an error 
```
HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information. for url: https://upload.pypi.org/legacy/
```
I am not sure why PyPI cares all of a sudden, but that _is_ invalid reStructuredText, hopefully this resolved the issue.