### PR TITLE
Fix for pii_search timestamp parsing

### DIFF
--- a/src/matchlight/search.py
+++ b/src/matchlight/search.py
@@ -158,6 +158,10 @@ class SearchMethods(object):
             raise matchlight.error.SDKError('Failed to get search results')
         for result in results:
             # This result can seemingly be in different formats.
+            try:
+                result['ts'] = int(result['ts'])
+            except ValueError:
+                pass
             if isinstance(result['ts'], six.text_type):
                 result['ts'] = datetime.datetime.strptime(
                     result['ts'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,7 +171,7 @@ def pii_search_email_only_results():
         },
         {
             'fields': ['email'],
-            'ts': 1558333205,
+            'ts': '1558333205',
             'source': 'https://www.reddit.com/r/AskReddit/comments/3oqj4a'
         },
     ]


### PR DESCRIPTION
The `pii_search` function was unable to handle integer timestamps encoded as strings.